### PR TITLE
Add SQLite DB, models and seed script (persistent activities)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+SQLAlchemy>=1.4

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -1,0 +1,108 @@
+"""Seed the SQLite database with the sample activities previously defined
+in the original in-memory app.
+
+Run this script after installing requirements:
+
+    python scripts/seed_db.py
+
+It is idempotent and will only insert activities that do not already exist.
+"""
+from pathlib import Path
+from src.models import create_tables, get_session, Activity, Participant
+
+
+def get_sample_activities():
+    return {
+        "Chess Club": {
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+            "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+        },
+        "Programming Class": {
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+            "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+        },
+        "Gym Class": {
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+            "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+        },
+        "Soccer Team": {
+            "description": "Join the school soccer team and compete in matches",
+            "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+            "max_participants": 22,
+            "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+        },
+        "Basketball Team": {
+            "description": "Practice and play basketball with the school team",
+            "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+        },
+        "Art Club": {
+            "description": "Explore your creativity through painting and drawing",
+            "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+        },
+        "Drama Club": {
+            "description": "Act, direct, and produce plays and performances",
+            "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+            "max_participants": 20,
+            "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+        },
+        "Math Club": {
+            "description": "Solve challenging problems and participate in math competitions",
+            "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+            "max_participants": 10,
+            "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+        },
+        "Debate Team": {
+            "description": "Develop public speaking and argumentation skills",
+            "schedule": "Fridays, 4:00 PM - 5:30 PM",
+            "max_participants": 12,
+            "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+        },
+    }
+
+
+def seed():
+    create_tables()
+    session = get_session()
+    try:
+        samples = get_sample_activities()
+        for name, meta in samples.items():
+            exists = session.query(Activity).filter(Activity.name == name).first()
+            if exists:
+                print(f"Skipping existing activity: {name}")
+                continue
+
+            a = Activity(
+                name=name,
+                description=meta.get("description"),
+                schedule=meta.get("schedule"),
+                max_participants=meta.get("max_participants"),
+            )
+            session.add(a)
+            session.flush()  # get id for association
+
+            for email in meta.get("participants", []):
+                p = session.query(Participant).filter(Participant.email == email).first()
+                if not p:
+                    p = Participant(email=email)
+                    session.add(p)
+                    session.flush()
+                a.participants.append(p)
+
+        session.commit()
+        print("Seeding complete.")
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    seed()

--- a/src/README.md
+++ b/src/README.md
@@ -7,24 +7,29 @@ A super simple FastAPI application that allows students to view and sign up for 
 - View all available extracurricular activities
 - Sign up for activities
 
-## Getting Started
+## Getting Started (with persistent DB)
 
 1. Install the dependencies:
 
-   ```
-   pip install fastapi uvicorn
-   ```
+```bash
+pip install -r requirements.txt
+```
 
-2. Run the application:
+2. Seed the database (this will create `activities.db` and insert sample activities):
 
-   ```
-   python app.py
-   ```
+```bash
+python scripts/seed_db.py
+```
 
-3. Open your browser and go to:
+3. Run the application (use uvicorn):
+
+```bash
+uvicorn src.app:app --reload
+```
+
+4. Open your browser and go to:
    - API documentation: http://localhost:8000/docs
    - Alternative documentation: http://localhost:8000/redoc
-
 ## API Endpoints
 
 | Method | Endpoint                                                          | Description                                                         |

--- a/src/app.py
+++ b/src/app.py
@@ -1,81 +1,31 @@
-"""
-High School Management System API
+"""Mergington High School Activities API backed by SQLite + SQLAlchemy
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
+This module uses SQLAlchemy models in `src/models.py` and provides the same
+public endpoints as before but backed by a persistent database.
 """
 
+import os
+from pathlib import Path
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
-import os
-from pathlib import Path
 
-app = FastAPI(title="Mergington High School API",
-              description="API for viewing and signing up for extracurricular activities")
+from .models import create_tables, get_session, Activity, Participant
 
-# Mount the static files directory
+app = FastAPI(
+    title="Mergington High School API",
+    description="API for viewing and signing up for extracurricular activities (persistent DB)",
+)
+
+# Mount static files directory
 current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
+app.mount("/static", StaticFiles(directory=os.path.join(current_dir, "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+
+@app.on_event("startup")
+def startup_event():
+    # Create DB tables when the app starts
+    create_tables()
 
 
 @app.get("/")
@@ -85,48 +35,72 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    session = get_session()
+    try:
+        activities = session.query(Activity).all()
+        result = {}
+        for a in activities:
+            result[a.name] = {
+                "description": a.description,
+                "schedule": a.schedule,
+                "max_participants": a.max_participants,
+                "participants": [p.email for p in a.participants],
+            }
+        return result
+    finally:
+        session.close()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    session = get_session()
+    try:
+        activity = session.query(Activity).filter(Activity.name == activity_name).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        # Check if participant exists or create
+        participant = session.query(Participant).filter(Participant.email == email).first()
+        if participant and participant in activity.participants:
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+        if activity.max_participants and len(activity.participants) >= activity.max_participants:
+            raise HTTPException(status_code=400, detail="Activity is full")
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+        if not participant:
+            participant = Participant(email=email)
+            session.add(participant)
+
+        activity.participants.append(participant)
+        session.add(activity)
+        session.commit()
+        return {"message": f"Signed up {email} for {activity_name}"}
+    finally:
+        session.close()
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    session = get_session()
+    try:
+        activity = session.query(Activity).filter(Activity.name == activity_name).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        participant = session.query(Participant).filter(Participant.email == email).first()
+        if not participant or participant not in activity.participants:
+            raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+        activity.participants.remove(participant)
+        session.add(activity)
+        session.commit()
+        return {"message": f"Unregistered {email} from {activity_name}"}
+    finally:
+        session.close()
 
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+
+if __name__ == "__main__":
+    # Allow running `python -m uvicorn src.app:app --reload` or similar; keep a simple runner
+    import uvicorn
+
+    uvicorn.run("src.app:app", host="127.0.0.1", port=8000, reload=True)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,54 @@
+from sqlalchemy import (
+    create_engine,
+    Column,
+    Integer,
+    String,
+    Text,
+    Table,
+    ForeignKey,
+)
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+# SQLite database (file will be created in the repository root)
+DATABASE_URL = "sqlite:///./activities.db"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+Base = declarative_base()
+
+# Association table for many-to-many relationship between activities and participants
+activity_participants = Table(
+    "activity_participants",
+    Base.metadata,
+    Column("activity_id", Integer, ForeignKey("activities.id")),
+    Column("participant_id", Integer, ForeignKey("participants.id")),
+)
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False, index=True)
+    description = Column(Text)
+    schedule = Column(String)
+    max_participants = Column(Integer)
+    participants = relationship(
+        "Participant", secondary=activity_participants, back_populates="activities"
+    )
+
+
+class Participant(Base):
+    __tablename__ = "participants"
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, nullable=False, index=True)
+    activities = relationship(
+        "Activity", secondary=activity_participants, back_populates="participants"
+    )
+
+
+def create_tables():
+    Base.metadata.create_all(bind=engine)
+
+
+def get_session():
+    return SessionLocal()


### PR DESCRIPTION
This PR introduces a small persistent backend for activities using SQLite and SQLAlchemy.

Changes:
- Add SQLAlchemy models and helper (`src/models.py`).
- Update `src/app.py` endpoints to use the DB instead of in-memory dict.
- Add `scripts/seed_db.py` to import sample activities into `activities.db` (idempotent).
- Update `requirements.txt` and `src/README.md` with setup and seed instructions.

Why:
- Provides a persistent data layer so activities and signups are preserved across restarts. This is the first step for adding auth, CRUD, and further features.

Note:
- Run `python scripts/seed_db.py` after installing requirements to populate the DB with the sample activities.
